### PR TITLE
TodoApp Control 부분의 로직 구현

### DIFF
--- a/jjanmo/client/src/components/control.ts
+++ b/jjanmo/client/src/components/control.ts
@@ -1,6 +1,7 @@
 import { dispatch, state } from '@/store'
 import { Filter } from '@/types'
 import { renderList } from './list'
+import { renderToggleAllBtn } from './form'
 
 const $controlContainer = document.querySelector('.control-container') as HTMLDivElement
 const $filterContainer = document.querySelector('.filter-container') as HTMLDivElement
@@ -14,14 +15,8 @@ export const renderControlContainer = () => {
   if (todoCount === 0) $controlContainer.classList.add('hidden')
   else $controlContainer.classList.remove('hidden')
 
-  renderTodoCount()
-}
-
-export const renderTodoCount = () => {
-  const todoCount = state.todos.length
   $todoCount.textContent = `${todoCount} items left`
 }
-
 // according to todo-item status
 export const renderClearCompletedBtn = () => {
   const { todos } = state
@@ -53,7 +48,8 @@ const handleClearCompletedBtnClick = () => {
   dispatch({ type: 'CLEAR_COMPLETED_ITEMS' })
 
   renderList()
-  renderTodoCount()
+  renderToggleAllBtn()
+  renderControlContainer()
   renderClearCompletedBtn()
   $clearCompletedBtn.blur()
 }

--- a/jjanmo/client/src/components/control.ts
+++ b/jjanmo/client/src/components/control.ts
@@ -1,7 +1,7 @@
 import { dispatch, state } from '@/store'
 import { Filter } from '@/types'
 import { renderList } from './list'
-import { renderToggleAllBtn } from './form'
+import { changeToggleBtnStyle, renderToggleAllBtn } from './form'
 
 const $controlContainer = document.querySelector('.control-container') as HTMLDivElement
 const $filterContainer = document.querySelector('.filter-container') as HTMLDivElement
@@ -15,7 +15,8 @@ export const renderControlContainer = () => {
   if (todoCount === 0) $controlContainer.classList.add('hidden')
   else $controlContainer.classList.remove('hidden')
 
-  $todoCount.textContent = `${todoCount} items left`
+  const activeTodoCount = state.todos.filter((todo) => todo.status === 'active').length
+  $todoCount.textContent = `${activeTodoCount} items left`
 }
 // according to todo-item status
 export const renderClearCompletedBtn = () => {
@@ -51,6 +52,7 @@ const handleClearCompletedBtnClick = () => {
   renderToggleAllBtn()
   renderControlContainer()
   renderClearCompletedBtn()
+  changeToggleBtnStyle()
   $clearCompletedBtn.blur()
 }
 

--- a/jjanmo/client/src/components/control.ts
+++ b/jjanmo/client/src/components/control.ts
@@ -1,5 +1,6 @@
 import { dispatch, state } from '@/store'
 import { Filter } from '@/types'
+import { renderList } from './list'
 
 const $controlContainer = document.querySelector('.control-container') as HTMLDivElement
 const $filterContainer = document.querySelector('.filter-container') as HTMLDivElement
@@ -40,7 +41,7 @@ const handleFilterClick = (e: Event) => {
   dispatch({ type: 'CHANGE_FILTER', payload: { filter } })
 
   changeFilterBtnStyle(filter)
-  console.log('@', state)
+  renderList()
 }
 
 const handleClearCompletedBtnClick = () => {

--- a/jjanmo/client/src/components/control.ts
+++ b/jjanmo/client/src/components/control.ts
@@ -1,0 +1,37 @@
+import { dispatch, state } from '@/store'
+
+const $controlContainer = document.querySelector('.control-container') as HTMLDivElement
+const $filterContainer = document.querySelector('.filter-container') as HTMLDivElement
+const $todoCount = document.querySelector('.todo-count') as HTMLDivElement
+const $clearCompletedBtn = document.querySelector('.clear-completed-btn') as HTMLButtonElement
+
+// by todo-item 개수
+export const renderControlContainer = () => {
+  const todoCount = state.todos.length
+  if (todoCount === 0) $controlContainer.classList.add('hidden')
+  else $controlContainer.classList.remove('hidden')
+
+  $todoCount.textContent = `${state.todos.length} items left`
+}
+
+// by todo-item 상태
+export const renderClearCompletedBtn = () => {
+  const { todos } = state
+  const completedCount = todos.filter((todo) => todo.status === 'completed').length
+  const $btnText = $clearCompletedBtn.querySelector('& > span') as HTMLSpanElement
+  if (completedCount > 0) $btnText.classList.remove('hidden')
+  else $btnText.classList.add('hidden')
+}
+
+const handleFilterClick = () => {}
+
+const handleClearCompletedBtnClick = () => {
+  dispatch({ type: 'CLEAR_COMPLETED_ITEMS' })
+}
+
+const init = () => {
+  $filterContainer.addEventListener('click', handleFilterClick)
+  $clearCompletedBtn.addEventListener('click', handleClearCompletedBtnClick)
+}
+
+init()

--- a/jjanmo/client/src/components/control.ts
+++ b/jjanmo/client/src/components/control.ts
@@ -1,9 +1,11 @@
 import { dispatch, state } from '@/store'
+import { Filter } from '@/types'
 
 const $controlContainer = document.querySelector('.control-container') as HTMLDivElement
 const $filterContainer = document.querySelector('.filter-container') as HTMLDivElement
 const $todoCount = document.querySelector('.todo-count') as HTMLDivElement
 const $clearCompletedBtn = document.querySelector('.clear-completed-btn') as HTMLButtonElement
+const $filterBtns = $filterContainer.querySelectorAll('button') as NodeListOf<HTMLButtonElement>
 
 // by todo-item 개수
 export const renderControlContainer = () => {
@@ -23,7 +25,23 @@ export const renderClearCompletedBtn = () => {
   else $btnText.classList.add('hidden')
 }
 
-const handleFilterClick = () => {}
+const changeFilterBtnStyle = (target: Filter) => {
+  $filterBtns.forEach((btn) => {
+    if (btn.dataset.filter === target) btn.classList.add('selected')
+    else btn.classList.remove('selected')
+  })
+}
+
+const handleFilterClick = (e: Event) => {
+  const target = e.target as HTMLElement
+  if (target.tagName !== 'BUTTON') return
+
+  const filter = target.dataset.filter as Filter
+  dispatch({ type: 'CHANGE_FILTER', payload: { filter } })
+
+  changeFilterBtnStyle(filter)
+  console.log('@', state)
+}
 
 const handleClearCompletedBtnClick = () => {
   dispatch({ type: 'CLEAR_COMPLETED_ITEMS' })

--- a/jjanmo/client/src/components/control.ts
+++ b/jjanmo/client/src/components/control.ts
@@ -8,16 +8,21 @@ const $todoCount = document.querySelector('.todo-count') as HTMLDivElement
 const $clearCompletedBtn = document.querySelector('.clear-completed-btn') as HTMLButtonElement
 const $filterBtns = $filterContainer.querySelectorAll('button') as NodeListOf<HTMLButtonElement>
 
-// by todo-item 개수
+// according to todo-item count
 export const renderControlContainer = () => {
   const todoCount = state.todos.length
   if (todoCount === 0) $controlContainer.classList.add('hidden')
   else $controlContainer.classList.remove('hidden')
 
-  $todoCount.textContent = `${state.todos.length} items left`
+  renderTodoCount()
 }
 
-// by todo-item 상태
+export const renderTodoCount = () => {
+  const todoCount = state.todos.length
+  $todoCount.textContent = `${todoCount} items left`
+}
+
+// according to todo-item status
 export const renderClearCompletedBtn = () => {
   const { todos } = state
   const completedCount = todos.filter((todo) => todo.status === 'completed').length
@@ -46,6 +51,11 @@ const handleFilterClick = (e: Event) => {
 
 const handleClearCompletedBtnClick = () => {
   dispatch({ type: 'CLEAR_COMPLETED_ITEMS' })
+
+  renderList()
+  renderTodoCount()
+  renderClearCompletedBtn()
+  $clearCompletedBtn.blur()
 }
 
 const init = () => {

--- a/jjanmo/client/src/components/form.ts
+++ b/jjanmo/client/src/components/form.ts
@@ -37,7 +37,7 @@ export const renderToggleAllBtn = () => {
   else $allToggleBtn.classList.remove('hidden')
 }
 
-const changeToggleBtnStyle = () => {
+export const changeToggleBtnStyle = () => {
   const { isAllCompleted } = state
   if (isAllCompleted) $allToggleBtn.classList.add('all-completed')
   else $allToggleBtn.classList.remove('all-completed')

--- a/jjanmo/client/src/components/form.ts
+++ b/jjanmo/client/src/components/form.ts
@@ -10,10 +10,12 @@ const $allToggleBtn = document.querySelector('.all-toggle-btn') as HTMLButtonEle
 
 const handleSubmit = (e: Event) => {
   e.preventDefault()
+  const text = $todoInput.value
+  if (!text) return
 
   const todo: Todo = {
     id: uuidv4(),
-    text: $todoInput.value,
+    text,
     status: 'active',
     createdAt: Date.now(),
     updatedAt: Date.now(),

--- a/jjanmo/client/src/components/form.ts
+++ b/jjanmo/client/src/components/form.ts
@@ -26,7 +26,6 @@ const handleSubmit = (e: Event) => {
   renderToggleAllBtn()
   renderList()
   renderControlContainer()
-
   $todoInput.value = ''
 }
 
@@ -55,6 +54,7 @@ const handleToggleAllBtbClick = () => {
 
 const init = () => {
   $todoForm.addEventListener('submit', handleSubmit)
+  $todoInput.addEventListener('blur', handleSubmit)
   $allToggleBtn.addEventListener('click', handleToggleAllBtbClick)
 }
 

--- a/jjanmo/client/src/components/form.ts
+++ b/jjanmo/client/src/components/form.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { state, dispatch } from '@/store'
 import { Todo } from '@/types'
 import { renderList } from '@/components/list'
+import { renderClearCompletedBtn, renderControlContainer } from './control'
 
 const $todoForm = document.querySelector('.todo-form') as HTMLFormElement
 const $todoInput = document.querySelector('.todo-input') as HTMLInputElement
@@ -22,6 +23,7 @@ const handleSubmit = (e: Event) => {
 
   renderToggleAllBtn()
   renderList()
+  renderControlContainer()
 
   $todoInput.value = ''
 }
@@ -46,6 +48,7 @@ const handleToggleAllBtbClick = () => {
 
   dispatch({ type: 'TOGGLE_ALL_TODO_ITEMS' })
   renderList()
+  renderClearCompletedBtn()
 }
 
 const init = () => {

--- a/jjanmo/client/src/components/list.ts
+++ b/jjanmo/client/src/components/list.ts
@@ -5,9 +5,10 @@ import { renderClearCompletedBtn, renderControlContainer } from './control'
 const $todoList = document.querySelector('.todo-list') as HTMLUListElement
 
 export const renderList = () => {
-  const { todos } = state
+  const { todos, filter } = state
 
-  const updated = todos.map((todo) => {
+  const filterd = filter === 'all' ? todos : todos.filter((todo) => todo.status === filter)
+  const updated = filterd.map((todo) => {
     const { id, text, status } = todo
     return `
       <li key=${id} class="todo-item" id=${id}>

--- a/jjanmo/client/src/components/list.ts
+++ b/jjanmo/client/src/components/list.ts
@@ -1,5 +1,6 @@
 import { dispatch, state } from '@/store'
 import { renderToggleAllBtn } from './form'
+import { renderClearCompletedBtn, renderControlContainer } from './control'
 
 const $todoList = document.querySelector('.todo-list') as HTMLUListElement
 
@@ -33,13 +34,14 @@ const handleClick = (e: Event) => {
     dispatch({ type: 'DELETE_TODO', payload: { id } })
     renderList()
     renderToggleAllBtn()
+    renderControlContainer()
     return
   }
 
   if (className.includes('checkbox')) {
     dispatch({ type: 'TOGGLE_TODO_ITEM', payload: { id } })
     renderList()
-    renderToggleAllBtn()
+    renderClearCompletedBtn()
     return
   }
 }

--- a/jjanmo/client/src/index.html
+++ b/jjanmo/client/src/index.html
@@ -18,15 +18,17 @@
 
         <ul class="todo-list"></ul>
 
-        <!-- <div class="control-container">
-          <div class="todo-count">3 items left</div>
+        <div class="control-container hidden">
+          <div class="todo-count"></div>
           <div class="filter-container">
-            <button class="filter-btn all">All</button>
+            <button class="filter-btn all selected">All</button>
             <button class="filter-btn active">Active</button>
             <button class="filter-btn completed">Completed</button>
           </div>
-          <button class="clear-completed-btn">Clear completed</button>
-        </div> -->
+          <button class="clear-completed-btn">
+            <span class="hidden">Clear completed</span>
+          </button>
+        </div>
       </main>
     </div>
   </body>

--- a/jjanmo/client/src/index.html
+++ b/jjanmo/client/src/index.html
@@ -21,9 +21,9 @@
         <div class="control-container hidden">
           <div class="todo-count"></div>
           <div class="filter-container">
-            <button class="filter-btn all selected">All</button>
-            <button class="filter-btn active">Active</button>
-            <button class="filter-btn completed">Completed</button>
+            <button class="filter-btn selected" data-filter="all">All</button>
+            <button class="filter-btn" data-filter="active">Active</button>
+            <button class="filter-btn" data-filter="completed"">Completed</button>
           </div>
           <button class="clear-completed-btn">
             <span class="hidden">Clear completed</span>

--- a/jjanmo/client/src/index.ts
+++ b/jjanmo/client/src/index.ts
@@ -1,4 +1,5 @@
 import '@/styles/index.css'
 import '@/store'
+import '@/components/control'
 import '@/components/form'
 import '@/components/list'

--- a/jjanmo/client/src/store.ts
+++ b/jjanmo/client/src/store.ts
@@ -1,39 +1,41 @@
-import { State, Action, Todo } from '@/types'
+import { State, ActionTypes } from '@/types'
 
 const state: State = {
   todos: [],
   isAllCompleted: false,
+  filter: 'all',
 }
 
-const dispatch = <T>({ type, payload }: Action<T>) => {
-  const updated = reducer({ type, payload })
+const dispatch = (action: ActionTypes) => {
+  const updated = reducer(action)
   Object.assign(state, updated)
 }
 
-const reducer = ({ type, payload }: Action<unknown>): State => {
+const reducer = (action: ActionTypes): State => {
+  const type = action.type
   switch (type) {
     case 'ADD_TODO': {
       return {
         ...state,
-        todos: [...state.todos, payload as Todo],
+        todos: [...state.todos, action.payload],
       }
     }
     case 'EDIT_TODO': {
-      const { id, text, updatedAt } = payload as Pick<Todo, 'id' | 'text' | 'updatedAt'>
+      const { id, text, updatedAt } = action.payload
       return {
         ...state,
         todos: state.todos.map((todo) => (todo.id === id ? { ...todo, text, updatedAt } : todo)),
       }
     }
     case 'DELETE_TODO': {
-      const { id } = payload as Pick<Todo, 'id'>
+      const { id } = action.payload
       return {
         ...state,
         todos: state.todos.filter((todo) => todo.id !== id),
       }
     }
     case 'TOGGLE_TODO_ITEM':
-      const { id } = payload as Pick<Todo, 'id'>
+      const { id } = action.payload
       return {
         ...state,
         todos: state.todos.map((todo) =>
@@ -45,7 +47,6 @@ const reducer = ({ type, payload }: Action<unknown>): State => {
         ...state,
         isAllCompleted: !state.isAllCompleted,
       }
-
     case 'TOGGLE_ALL_TODO_ITEMS':
       return {
         ...state,
@@ -55,6 +56,12 @@ const reducer = ({ type, payload }: Action<unknown>): State => {
       return {
         ...state,
         todos: state.todos.filter((todo) => todo.status !== 'completed'),
+      }
+    case 'CHANGE_FILTER':
+      const { filter } = action.payload
+      return {
+        ...state,
+        filter,
       }
     default:
       return state

--- a/jjanmo/client/src/store.ts
+++ b/jjanmo/client/src/store.ts
@@ -53,9 +53,11 @@ const reducer = (action: ActionTypes): State => {
         todos: state.todos.map((todo) => ({ ...todo, status: state.isAllCompleted ? 'completed' : 'active' })),
       }
     case 'CLEAR_COMPLETED_ITEMS':
+      const activeTodos = state.todos.filter((todo) => todo.status === 'active')
       return {
         ...state,
-        todos: state.todos.filter((todo) => todo.status !== 'completed'),
+        todos: activeTodos,
+        isAllCompleted: activeTodos.length === 0 ? false : state.isAllCompleted,
       }
     case 'CHANGE_FILTER':
       const { filter } = action.payload

--- a/jjanmo/client/src/store.ts
+++ b/jjanmo/client/src/store.ts
@@ -53,8 +53,8 @@ const reducer = ({ type, payload }: Action<unknown>): State => {
       }
     case 'CLEAR_COMPLETED_ITEMS':
       return {
-        todos: [],
-        isAllCompleted: false,
+        ...state,
+        todos: state.todos.filter((todo) => todo.status !== 'completed'),
       }
     default:
       return state

--- a/jjanmo/client/src/styles/index.css
+++ b/jjanmo/client/src/styles/index.css
@@ -133,6 +133,10 @@ main {
   font-size: 20px;
   color: var(--gray-light);
   cursor: pointer;
+
+  &:hover {
+    color: var(--red);
+  }
 }
 
 .control-container {

--- a/jjanmo/client/src/styles/index.css
+++ b/jjanmo/client/src/styles/index.css
@@ -3,11 +3,11 @@
 
 #app {
   width: 600px;
-  margin: auto;
+  margin: 50px auto 80px;
 }
 
 .title {
-  margin: 50px 0;
+  margin-bottom: 50px;
   font-size: 80px;
   font-weight: 300;
   text-align: center;

--- a/jjanmo/client/src/styles/index.css
+++ b/jjanmo/client/src/styles/index.css
@@ -151,6 +151,7 @@ main {
 .filter-btn {
   font-weight: 300;
   padding: 6px;
+  border: 1px solid transparent;
   border-radius: 4px;
 
   &:focus {

--- a/jjanmo/client/src/styles/index.css
+++ b/jjanmo/client/src/styles/index.css
@@ -150,7 +150,7 @@ main {
 
 .filter-btn {
   font-weight: 300;
-  padding: 6px;
+  padding: 4px 8px;
   border: 1px solid transparent;
   border-radius: 4px;
 

--- a/jjanmo/client/src/styles/index.css
+++ b/jjanmo/client/src/styles/index.css
@@ -2,7 +2,7 @@
 @import './global.css';
 
 #app {
-  width: 500px;
+  width: 600px;
   margin: auto;
 }
 
@@ -53,15 +53,6 @@ main {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   letter-spacing: 0.2px;
 
-  /* TODO */
-  /* todo-item이 없을때만! */
-  /* box-shadow:
-    0 2px 4px 0 rgba(0, 0, 0, 0.2),
-    0 25px 50px 0 rgba(0, 0, 0, 0.1); 
-  */
-
-  box-shadow: inset 0 -2px 1px rgba(0, 0, 0, 0.03);
-
   &::placeholder {
     font-style: italic;
     color: var(--gray-light);
@@ -77,6 +68,10 @@ main {
   width: 100%;
   height: 60px;
   border-bottom: 1px solid var(--item-border);
+
+  &:hover .todo-item-delete-btn {
+    display: block;
+  }
 }
 .todo-item:first-child {
   border-top: 1px solid var(--item-border);
@@ -133,7 +128,7 @@ main {
 }
 
 .todo-item-delete-btn {
-  border: 0;
+  display: none;
   background-color: transparent;
   font-size: 20px;
   color: var(--gray-light);
@@ -153,23 +148,29 @@ main {
   border-bottom: 1px solid var(--item-border);
 }
 
-.filter-btn,
-.clear-completed-btn {
-  all: unset;
+.filter-btn {
+  font-weight: 300;
   padding: 6px;
-  margin: 0 3px;
-  /* border: 1px solid var(--red); */
   border-radius: 4px;
-  background-color: transparent;
-  cursor: pointer;
 
   &:focus {
     box-shadow: 0 0 2px 2px var(--red-light);
   }
+  &.selected {
+    border: 1px solid var(--red);
+  }
 }
 
 .clear-completed-btn {
-  margin: 0;
+  width: 120px;
+  font-weight: 300;
+
+  &:focus {
+    box-shadow: 0 0 2px 2px var(--red-light);
+  }
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .hidden {

--- a/jjanmo/client/src/styles/reset.css
+++ b/jjanmo/client/src/styles/reset.css
@@ -138,3 +138,12 @@ input {
   outline: none;
   border: none;
 }
+
+button {
+  outline: none;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+}

--- a/jjanmo/client/src/types.ts
+++ b/jjanmo/client/src/types.ts
@@ -8,21 +8,50 @@ export interface Todo {
   updatedAt: number
 }
 
+export type Filter = 'all' | 'active' | 'completed'
+
 export interface State {
   todos: Todo[]
   isAllCompleted: boolean
+  filter: Filter
 }
 
-export type ActionType =
-  | 'ADD_TODO'
-  | 'EDIT_TODO'
-  | 'DELETE_TODO'
-  | 'TOGGLE_TODO_ITEM'
-  | 'CHANGE_TOGGLE_ALL_BTN_VISIBILITY'
-  | 'TOGGLE_ALL_TODO_ITEMS'
-  | 'CLEAR_COMPLETED_ITEMS'
+export type ActionTypes =
+  | AddTodoAction
+  | EditTodoAction
+  | DeletTodoAction
+  | ToggleTodoAction
+  | ChangToggleAllBtnVisibilityAction
+  | ToggleAllTodoItemsAction
+  | ClearCompletedItemsAction
+  | ChangeFilterAction
 
-export interface Action<T> {
-  type: ActionType
-  payload?: T
+export type AddTodoAction = {
+  type: 'ADD_TODO'
+  payload: Todo
+}
+export type EditTodoAction = {
+  type: 'EDIT_TODO'
+  payload: Pick<Todo, 'id' | 'text' | 'updatedAt'>
+}
+export type DeletTodoAction = {
+  type: 'DELETE_TODO'
+  payload: Pick<Todo, 'id'>
+}
+export type ToggleTodoAction = {
+  type: 'TOGGLE_TODO_ITEM'
+  payload: Pick<Todo, 'id'>
+}
+export type ChangeFilterAction = {
+  type: 'CHANGE_FILTER'
+  payload: Pick<State, 'filter'>
+}
+export type ToggleAllTodoItemsAction = {
+  type: 'TOGGLE_ALL_TODO_ITEMS'
+}
+export type ChangToggleAllBtnVisibilityAction = {
+  type: 'CHANGE_TOGGLE_ALL_BTN_VISIBILITY'
+}
+export type ClearCompletedItemsAction = {
+  type: 'CLEAR_COMPLETED_ITEMS'
 }


### PR DESCRIPTION
## Describe your PR 📝

- TodoApp의 하단의 Control 영역에서 할 수 있는 기능 구현에 대한 PR입니다.

## How to change 🛠
- action 타입에 대한 리팩토링 
  - AsIs : 제네릭을 통한 타입 유연성을 가져가고자했는데, 결국 타입 단언을 통한 타입 추론이 됨
  - ToBe : 액션에 대한 각 타입을 구현하여 payload에 대한 자동타입추론을 할 수 있게 변경
- control 영역은 todo아이템이 0이상일때만 노출되도록 구현
- active todo의 숫자를 노출하도록 구현
- 필터 버튼에 따라서 리스트가 필터링 되도록 구현
- clear completed 버튼의 동작 구현
- clear completed 버튼과 전체 토글 버튼과 연결되는 부분 추가 수정
- 기타 소소한 버그/오류 수정 및 스타일 수정

## Checklist for review ✅

- 언제나 피드백/커멘트는 환영합니다.

## Comments for future 🌱

- 드디어 마지막 투두아이템 수정 기능을 구현합니다.
