### PR TITLE
TodoApp에서 TodoItem의 편집 기능 구현

### DIFF
--- a/jjanmo/client/src/components/control.ts
+++ b/jjanmo/client/src/components/control.ts
@@ -18,6 +18,7 @@ export const renderControlContainer = () => {
   const activeTodoCount = state.todos.filter((todo) => todo.status === 'active').length
   $todoCount.textContent = `${activeTodoCount} items left`
 }
+
 // according to todo-item status
 export const renderClearCompletedBtn = () => {
   const { todos } = state

--- a/jjanmo/client/src/components/control.ts
+++ b/jjanmo/client/src/components/control.ts
@@ -9,20 +9,19 @@ const $todoCount = document.querySelector('.todo-count') as HTMLDivElement
 const $clearCompletedBtn = document.querySelector('.clear-completed-btn') as HTMLButtonElement
 const $filterBtns = $filterContainer.querySelectorAll('button') as NodeListOf<HTMLButtonElement>
 
-// according to todo-item count
 export const renderControlContainer = () => {
   const todoCount = state.todos.length
   if (todoCount === 0) $controlContainer.classList.add('hidden')
   else $controlContainer.classList.remove('hidden')
+}
 
+export const renderActiveTodoCount = () => {
   const activeTodoCount = state.todos.filter((todo) => todo.status === 'active').length
   $todoCount.textContent = `${activeTodoCount} items left`
 }
 
-// according to todo-item status
 export const renderClearCompletedBtn = () => {
-  const { todos } = state
-  const completedCount = todos.filter((todo) => todo.status === 'completed').length
+  const completedCount = state.todos.filter((todo) => todo.status === 'completed').length
   const $btnText = $clearCompletedBtn.querySelector('& > span') as HTMLSpanElement
   if (completedCount > 0) $btnText.classList.remove('hidden')
   else $btnText.classList.add('hidden')

--- a/jjanmo/client/src/components/control.ts
+++ b/jjanmo/client/src/components/control.ts
@@ -27,9 +27,10 @@ export const renderClearCompletedBtn = () => {
   else $btnText.classList.add('hidden')
 }
 
-const changeFilterBtnStyle = (target: Filter) => {
+export const changeFilterBtnStyle = () => {
+  const filter = state.filter
   $filterBtns.forEach((btn) => {
-    if (btn.dataset.filter === target) btn.classList.add('selected')
+    if (btn.dataset.filter === filter) btn.classList.add('selected')
     else btn.classList.remove('selected')
   })
 }
@@ -41,18 +42,22 @@ const handleFilterClick = (e: Event) => {
   const filter = target.dataset.filter as Filter
   dispatch({ type: 'CHANGE_FILTER', payload: { filter } })
 
-  changeFilterBtnStyle(filter)
+  changeFilterBtnStyle()
   renderList()
 }
 
 const handleClearCompletedBtnClick = () => {
   dispatch({ type: 'CLEAR_COMPLETED_ITEMS' })
+  if (state.todos.length === 0) {
+    dispatch({ type: 'RESET_ALL' })
+  }
 
   renderList()
   renderToggleAllBtn()
   renderControlContainer()
   renderClearCompletedBtn()
   changeToggleBtnStyle()
+  changeFilterBtnStyle()
   $clearCompletedBtn.blur()
 }
 

--- a/jjanmo/client/src/components/form.ts
+++ b/jjanmo/client/src/components/form.ts
@@ -43,19 +43,20 @@ export const changeToggleBtnStyle = () => {
   else $allToggleBtn.classList.remove('all-completed')
 }
 
-const handleToggleAllBtbClick = () => {
+const handleToggleAllBtnClick = () => {
   dispatch({ type: 'CHANGE_TOGGLE_ALL_BTN_VISIBILITY' })
   dispatch({ type: 'TOGGLE_ALL_TODO_ITEMS', payload: { updatedAt: Date.now() } })
 
   changeToggleBtnStyle()
   renderList()
   renderClearCompletedBtn()
+  renderControlContainer()
 }
 
 const init = () => {
   $todoForm.addEventListener('submit', handleSubmit)
   $todoInput.addEventListener('blur', handleSubmit)
-  $allToggleBtn.addEventListener('click', handleToggleAllBtbClick)
+  $allToggleBtn.addEventListener('click', handleToggleAllBtnClick)
 }
 
 init()

--- a/jjanmo/client/src/components/form.ts
+++ b/jjanmo/client/src/components/form.ts
@@ -19,7 +19,6 @@ const handleSubmit = (e: Event) => {
     status: 'active',
     createdAt: Date.now(),
     updatedAt: Date.now(),
-    mode: 'view',
   }
 
   dispatch({ type: 'ADD_TODO', payload: todo })

--- a/jjanmo/client/src/components/form.ts
+++ b/jjanmo/client/src/components/form.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { state, dispatch } from '@/store'
 import { Todo } from '@/types'
 import { renderList } from '@/components/list'
-import { renderClearCompletedBtn, renderControlContainer } from './control'
+import { renderActiveTodoCount, renderClearCompletedBtn, renderControlContainer } from './control'
 
 const $todoForm = document.querySelector('.todo-form') as HTMLFormElement
 const $todoInput = document.querySelector('.todo-input') as HTMLInputElement
@@ -23,34 +23,38 @@ const handleSubmit = (e: Event) => {
 
   dispatch({ type: 'ADD_TODO', payload: todo })
 
-  renderToggleAllBtn()
   renderList()
+  renderToggleAllBtn()
   renderControlContainer()
+  renderActiveTodoCount()
+  changeToggleBtnStyle()
   $todoInput.value = ''
 }
 
 export const renderToggleAllBtn = () => {
-  const { todos } = state
-
-  const todoCount = todos.length
+  const todoCount = state.todos.length
   if (todoCount === 0) $allToggleBtn.classList.add('hidden')
   else $allToggleBtn.classList.remove('hidden')
 }
 
 export const changeToggleBtnStyle = () => {
-  const { isAllCompleted } = state
+  const isAllCompleted = state.todos.every((todo) => todo.status === 'completed')
   if (isAllCompleted) $allToggleBtn.classList.add('all-completed')
   else $allToggleBtn.classList.remove('all-completed')
 }
 
 const handleToggleAllBtnClick = () => {
-  dispatch({ type: 'CHANGE_TOGGLE_ALL_BTN_VISIBILITY' })
-  dispatch({ type: 'TOGGLE_ALL_TODO_ITEMS', payload: { updatedAt: Date.now() } })
+  const isAllCompleted = state.todos.every((todo) => todo.status === 'completed')
+  dispatch({
+    type: 'TOGGLE_ALL_TODO_ITEMS',
+    payload: { updatedAt: Date.now(), status: isAllCompleted ? 'active' : 'completed' },
+  })
 
   changeToggleBtnStyle()
-  renderList()
   renderClearCompletedBtn()
   renderControlContainer()
+  renderActiveTodoCount()
+  renderList()
 }
 
 const init = () => {

--- a/jjanmo/client/src/components/form.ts
+++ b/jjanmo/client/src/components/form.ts
@@ -19,6 +19,7 @@ const handleSubmit = (e: Event) => {
     status: 'active',
     createdAt: Date.now(),
     updatedAt: Date.now(),
+    mode: 'view',
   }
 
   dispatch({ type: 'ADD_TODO', payload: todo })

--- a/jjanmo/client/src/components/form.ts
+++ b/jjanmo/client/src/components/form.ts
@@ -45,9 +45,9 @@ export const changeToggleBtnStyle = () => {
 
 const handleToggleAllBtbClick = () => {
   dispatch({ type: 'CHANGE_TOGGLE_ALL_BTN_VISIBILITY' })
-  changeToggleBtnStyle()
+  dispatch({ type: 'TOGGLE_ALL_TODO_ITEMS', payload: { updatedAt: Date.now() } })
 
-  dispatch({ type: 'TOGGLE_ALL_TODO_ITEMS' })
+  changeToggleBtnStyle()
   renderList()
   renderClearCompletedBtn()
 }

--- a/jjanmo/client/src/components/list.ts
+++ b/jjanmo/client/src/components/list.ts
@@ -54,6 +54,7 @@ const handleClick = (e: Event) => {
     dispatch({ type: 'TOGGLE_TODO_ITEM', payload: { id, updatedAt: Date.now() } })
     renderList()
     renderClearCompletedBtn()
+    renderControlContainer()
     return
   }
 }

--- a/jjanmo/client/src/components/list.ts
+++ b/jjanmo/client/src/components/list.ts
@@ -1,6 +1,6 @@
 import { dispatch, state } from '@/store'
-import { renderToggleAllBtn } from './form'
-import { changeFilterBtnStyle, renderClearCompletedBtn, renderControlContainer } from './control'
+import { changeToggleBtnStyle, renderToggleAllBtn } from './form'
+import { changeFilterBtnStyle, renderActiveTodoCount, renderClearCompletedBtn, renderControlContainer } from './control'
 import { Mode } from '@/types'
 
 const $todoList = document.querySelector('.todo-list') as HTMLUListElement
@@ -44,17 +44,21 @@ const handleClick = (e: Event) => {
     }
 
     renderList()
-    renderToggleAllBtn()
     renderControlContainer()
+    renderActiveTodoCount()
+    renderToggleAllBtn()
     changeFilterBtnStyle()
     return
   }
 
   if (className.includes('checkbox')) {
     dispatch({ type: 'TOGGLE_TODO_ITEM', payload: { id, updatedAt: Date.now() } })
+
     renderList()
-    renderClearCompletedBtn()
     renderControlContainer()
+    renderActiveTodoCount()
+    renderClearCompletedBtn()
+    changeToggleBtnStyle()
     return
   }
 }
@@ -79,19 +83,19 @@ const handleDbClick = (e: Event) => {
   changeTodoItemMode($todoItem, 'edit')
   $todoItemEditInput.focus()
 
+  const updateTodoItemText = () => {
+    const text = $todoItemEditInput.value
+    dispatch({ type: 'EDIT_TODO', payload: { id: $todoItem.id, text, updatedAt: Date.now() } })
+
+    changeTodoItemMode($todoItem, 'view')
+    renderList()
+  }
+
   $todoItemForm.addEventListener('submit', (e: Event) => {
     e.preventDefault()
-    const text = $todoItemEditInput.value
-    dispatch({ type: 'EDIT_TODO', payload: { id: $todoItem.id, text, updatedAt: Date.now() } })
-    renderList()
-    changeTodoItemMode($todoItem, 'view')
+    updateTodoItemText()
   })
-  $todoItemEditInput.addEventListener('blur', () => {
-    const text = $todoItemEditInput.value
-    dispatch({ type: 'EDIT_TODO', payload: { id: $todoItem.id, text, updatedAt: Date.now() } })
-    renderList()
-    changeTodoItemMode($todoItem, 'view')
-  })
+  $todoItemEditInput.addEventListener('blur', updateTodoItemText)
 }
 
 const init = () => {

--- a/jjanmo/client/src/components/list.ts
+++ b/jjanmo/client/src/components/list.ts
@@ -45,7 +45,7 @@ const handleClick = (e: Event) => {
   }
 
   if (className.includes('checkbox')) {
-    dispatch({ type: 'TOGGLE_TODO_ITEM', payload: { id } })
+    dispatch({ type: 'TOGGLE_TODO_ITEM', payload: { id, updatedAt: Date.now() } })
     renderList()
     renderClearCompletedBtn()
     return

--- a/jjanmo/client/src/components/list.ts
+++ b/jjanmo/client/src/components/list.ts
@@ -1,6 +1,6 @@
 import { dispatch, state } from '@/store'
 import { renderToggleAllBtn } from './form'
-import { renderClearCompletedBtn, renderControlContainer } from './control'
+import { changeFilterBtnStyle, renderClearCompletedBtn, renderControlContainer } from './control'
 
 const $todoList = document.querySelector('.todo-list') as HTMLUListElement
 
@@ -33,9 +33,14 @@ const handleClick = (e: Event) => {
 
   if (className.includes('delete')) {
     dispatch({ type: 'DELETE_TODO', payload: { id } })
+    if (state.todos.length === 0) {
+      dispatch({ type: 'RESET_ALL' })
+    }
+
     renderList()
     renderToggleAllBtn()
     renderControlContainer()
+    changeFilterBtnStyle()
     return
   }
 

--- a/jjanmo/client/src/store.ts
+++ b/jjanmo/client/src/store.ts
@@ -34,7 +34,7 @@ const reducer = (action: ActionTypes): State => {
         todos: state.todos.filter((todo) => todo.id !== id),
       }
     }
-    case 'TOGGLE_TODO_ITEM':
+    case 'TOGGLE_TODO_ITEM': {
       const { id } = action.payload
       return {
         ...state,
@@ -42,29 +42,41 @@ const reducer = (action: ActionTypes): State => {
           todo.id === id ? { ...todo, status: todo.status === 'active' ? 'completed' : 'active' } : todo
         ),
       }
-    case 'CHANGE_TOGGLE_ALL_BTN_VISIBILITY':
+    }
+    case 'CHANGE_TOGGLE_ALL_BTN_VISIBILITY': {
       return {
         ...state,
         isAllCompleted: !state.isAllCompleted,
       }
-    case 'TOGGLE_ALL_TODO_ITEMS':
+    }
+    case 'TOGGLE_ALL_TODO_ITEMS': {
       return {
         ...state,
         todos: state.todos.map((todo) => ({ ...todo, status: state.isAllCompleted ? 'completed' : 'active' })),
       }
-    case 'CLEAR_COMPLETED_ITEMS':
+    }
+    case 'CLEAR_COMPLETED_ITEMS': {
       const activeTodos = state.todos.filter((todo) => todo.status === 'active')
       return {
         ...state,
         todos: activeTodos,
         isAllCompleted: activeTodos.length === 0 ? false : state.isAllCompleted,
       }
-    case 'CHANGE_FILTER':
+    }
+    case 'CHANGE_FILTER': {
       const { filter } = action.payload
       return {
         ...state,
         filter,
       }
+    }
+    case 'RESET_ALL': {
+      return {
+        todos: [],
+        isAllCompleted: false,
+        filter: 'all',
+      }
+    }
     default:
       return state
   }

--- a/jjanmo/client/src/store.ts
+++ b/jjanmo/client/src/store.ts
@@ -2,7 +2,6 @@ import { State, ActionTypes } from '@/types'
 
 const state: State = {
   todos: [],
-  isAllCompleted: false,
   filter: 'all',
 }
 
@@ -43,29 +42,21 @@ const reducer = (action: ActionTypes): State => {
         ),
       }
     }
-    case 'CHANGE_TOGGLE_ALL_BTN_VISIBILITY': {
-      return {
-        ...state,
-        isAllCompleted: !state.isAllCompleted,
-      }
-    }
     case 'TOGGLE_ALL_TODO_ITEMS': {
-      const { updatedAt } = action.payload
+      const { status, updatedAt } = action.payload
       return {
         ...state,
         todos: state.todos.map((todo) => ({
           ...todo,
-          status: state.isAllCompleted ? 'completed' : 'active',
+          status,
           updatedAt,
         })),
       }
     }
     case 'CLEAR_COMPLETED_ITEMS': {
-      const activeTodos = state.todos.filter((todo) => todo.status === 'active')
       return {
         ...state,
-        todos: activeTodos,
-        isAllCompleted: activeTodos.length === 0 ? false : state.isAllCompleted,
+        todos: state.todos.filter((todo) => todo.status === 'active'),
       }
     }
     case 'CHANGE_FILTER': {
@@ -78,7 +69,6 @@ const reducer = (action: ActionTypes): State => {
     case 'RESET_ALL': {
       return {
         todos: [],
-        isAllCompleted: false,
         filter: 'all',
       }
     }

--- a/jjanmo/client/src/store.ts
+++ b/jjanmo/client/src/store.ts
@@ -35,11 +35,11 @@ const reducer = (action: ActionTypes): State => {
       }
     }
     case 'TOGGLE_TODO_ITEM': {
-      const { id } = action.payload
+      const { id, updatedAt } = action.payload
       return {
         ...state,
         todos: state.todos.map((todo) =>
-          todo.id === id ? { ...todo, status: todo.status === 'active' ? 'completed' : 'active' } : todo
+          todo.id === id ? { ...todo, status: todo.status === 'active' ? 'completed' : 'active', updatedAt } : todo
         ),
       }
     }
@@ -50,9 +50,14 @@ const reducer = (action: ActionTypes): State => {
       }
     }
     case 'TOGGLE_ALL_TODO_ITEMS': {
+      const { updatedAt } = action.payload
       return {
         ...state,
-        todos: state.todos.map((todo) => ({ ...todo, status: state.isAllCompleted ? 'completed' : 'active' })),
+        todos: state.todos.map((todo) => ({
+          ...todo,
+          status: state.isAllCompleted ? 'completed' : 'active',
+          updatedAt,
+        })),
       }
     }
     case 'CLEAR_COMPLETED_ITEMS': {

--- a/jjanmo/client/src/styles/index.css
+++ b/jjanmo/client/src/styles/index.css
@@ -50,7 +50,6 @@ main {
   padding-left: 60px;
   font-size: 24px;
   font-weight: 300;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   letter-spacing: 0.2px;
 
   &::placeholder {
@@ -105,12 +104,29 @@ main {
     transform: translate(1px, 1px); /* 미세조정 */
   }
 }
+
 .todo-content {
   flex: 1;
-  padding: 0 15px;
+  padding-left: 15px;
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+.todo-item-edit-form {
+  width: 100%;
+  height: 100%;
+}
+.todo-item-edit-input {
+  width: 100%;
+  height: 56px;
+  font-size: 24px;
+  font-weight: 300;
+  letter-spacing: 0.2px;
+  box-sizing: border-box;
+
+  &:focus {
+    box-shadow: 0 0 2px 2px var(--red-light);
+  }
 }
 
 .todo-text {
@@ -129,7 +145,7 @@ main {
 
 .todo-item-delete-btn {
   display: none;
-  background-color: transparent;
+  margin-right: 15px;
   font-size: 20px;
   color: var(--gray-light);
   cursor: pointer;

--- a/jjanmo/client/src/styles/reset.css
+++ b/jjanmo/client/src/styles/reset.css
@@ -137,6 +137,7 @@ a {
 input {
   outline: none;
   border: none;
+  font-family: inherit;
 }
 
 button {

--- a/jjanmo/client/src/types.ts
+++ b/jjanmo/client/src/types.ts
@@ -13,7 +13,6 @@ export type Filter = 'all' | 'active' | 'completed'
 
 export interface State {
   todos: Todo[]
-  isAllCompleted: boolean
   filter: Filter
 }
 
@@ -22,7 +21,6 @@ export type ActionTypes =
   | EditTodoAction
   | DeletTodoAction
   | ToggleTodoItemAction
-  | ChangToggleAllBtnVisibilityAction
   | ToggleAllTodoItemsAction
   | ClearCompletedItemsAction
   | ChangeFilterAction
@@ -50,10 +48,7 @@ export type ChangeFilterAction = {
 }
 export type ToggleAllTodoItemsAction = {
   type: 'TOGGLE_ALL_TODO_ITEMS'
-  payload: Pick<Todo, 'updatedAt'>
-}
-export type ChangToggleAllBtnVisibilityAction = {
-  type: 'CHANGE_TOGGLE_ALL_BTN_VISIBILITY'
+  payload: Pick<Todo, 'updatedAt' | 'status'>
 }
 export type ClearCompletedItemsAction = {
   type: 'CLEAR_COMPLETED_ITEMS'

--- a/jjanmo/client/src/types.ts
+++ b/jjanmo/client/src/types.ts
@@ -7,7 +7,6 @@ export interface Todo {
   status: Status
   createdAt: number
   updatedAt: number
-  mode: Mode
 }
 
 export type Filter = 'all' | 'active' | 'completed'
@@ -21,7 +20,6 @@ export interface State {
 export type ActionTypes =
   | AddTodoAction
   | EditTodoAction
-  | ChangeTodoModeAction
   | DeletTodoAction
   | ToggleTodoItemAction
   | ChangToggleAllBtnVisibilityAction
@@ -37,10 +35,6 @@ export type AddTodoAction = {
 export type EditTodoAction = {
   type: 'EDIT_TODO'
   payload: Pick<Todo, 'id' | 'text' | 'updatedAt'>
-}
-export type ChangeTodoModeAction = {
-  type: 'CHANGE_TODO_MODE'
-  payload: Pick<Todo, 'id'>
 }
 export type DeletTodoAction = {
   type: 'DELETE_TODO'

--- a/jjanmo/client/src/types.ts
+++ b/jjanmo/client/src/types.ts
@@ -20,7 +20,7 @@ export type ActionTypes =
   | AddTodoAction
   | EditTodoAction
   | DeletTodoAction
-  | ToggleTodoAction
+  | ToggleTodoItemAction
   | ChangToggleAllBtnVisibilityAction
   | ToggleAllTodoItemsAction
   | ClearCompletedItemsAction
@@ -39,9 +39,9 @@ export type DeletTodoAction = {
   type: 'DELETE_TODO'
   payload: Pick<Todo, 'id'>
 }
-export type ToggleTodoAction = {
+export type ToggleTodoItemAction = {
   type: 'TOGGLE_TODO_ITEM'
-  payload: Pick<Todo, 'id'>
+  payload: Pick<Todo, 'id' | 'updatedAt'>
 }
 export type ChangeFilterAction = {
   type: 'CHANGE_FILTER'
@@ -49,6 +49,7 @@ export type ChangeFilterAction = {
 }
 export type ToggleAllTodoItemsAction = {
   type: 'TOGGLE_ALL_TODO_ITEMS'
+  payload: Pick<Todo, 'updatedAt'>
 }
 export type ChangToggleAllBtnVisibilityAction = {
   type: 'CHANGE_TOGGLE_ALL_BTN_VISIBILITY'

--- a/jjanmo/client/src/types.ts
+++ b/jjanmo/client/src/types.ts
@@ -25,6 +25,7 @@ export type ActionTypes =
   | ToggleAllTodoItemsAction
   | ClearCompletedItemsAction
   | ChangeFilterAction
+  | ResetAllAction
 
 export type AddTodoAction = {
   type: 'ADD_TODO'
@@ -54,4 +55,7 @@ export type ChangToggleAllBtnVisibilityAction = {
 }
 export type ClearCompletedItemsAction = {
   type: 'CLEAR_COMPLETED_ITEMS'
+}
+export type ResetAllAction = {
+  type: 'RESET_ALL'
 }

--- a/jjanmo/client/src/types.ts
+++ b/jjanmo/client/src/types.ts
@@ -1,4 +1,5 @@
 export type Status = 'active' | 'completed'
+export type Mode = 'view' | 'edit'
 
 export interface Todo {
   id: string
@@ -6,6 +7,7 @@ export interface Todo {
   status: Status
   createdAt: number
   updatedAt: number
+  mode: Mode
 }
 
 export type Filter = 'all' | 'active' | 'completed'
@@ -19,6 +21,7 @@ export interface State {
 export type ActionTypes =
   | AddTodoAction
   | EditTodoAction
+  | ChangeTodoModeAction
   | DeletTodoAction
   | ToggleTodoItemAction
   | ChangToggleAllBtnVisibilityAction
@@ -34,6 +37,10 @@ export type AddTodoAction = {
 export type EditTodoAction = {
   type: 'EDIT_TODO'
   payload: Pick<Todo, 'id' | 'text' | 'updatedAt'>
+}
+export type ChangeTodoModeAction = {
+  type: 'CHANGE_TODO_MODE'
+  payload: Pick<Todo, 'id'>
 }
 export type DeletTodoAction = {
   type: 'DELETE_TODO'


### PR DESCRIPTION
## Describe your PR 📝

- 주요 작업은 투두아이템의 편집 기능 구현에 대한 PR입니다.
- 전반적인 플로우는 아래와 같습니다.
  - 투두아이템이 추가될 때 모드 조건(view mode/edite mode)에 따라 노출될 HTML을 추가한다.
  - 더블클릭이벤트에 의해 view mode에서 edit mode로 변경된다.
  - edit mode에서 submit 이벤트 혹은 blur 이벤트가 발생하면 해당 투두아이템의 텍스트가 업데이트되고 다시 view mode로 변환된다.
 

## How to change 🛠
- 리셋 로직 구현 : 투두아이템이 삭제되거나, 완료된 아이템을 클리어시킬때 최종 아이템의 수가 0인경우 모든 상태가 처음 상태로 돌아가는게 맞다고 생각하였고, 이에 맞게 2가지 로직에 있는 경우 아이템의 개수를 체크하여 리셋 로직을 수행하도록 변경
- Mode 타입 삭제 : 굳이 TodoItem 안에 Mode 라는 상태로 관리할 필요가 없음
- 리스트에 아이템이 추가될 때 HTML과 이를 사용할 수 있는 플래그(여기서는 data-*) 구현
- 더블클릭 이벤트 및 일련의 편집과정의 이벤트 로직 구현
- 기타 랜더링 버그 수정(랜더링 함수가 빠진 부분에 관련 랜더링 함수 추가)

## Checklist for review ✅
- 피드백 / 커멘트는 언제나 환영입니다.

## Comments for future 🌱

- 전반적인 대표적인 기능 구현은 끝!
- 리팩토링할 부분에 대해서 고민할 예정입니다.
